### PR TITLE
DeepLAPI導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 /node_modules
 /vendor/bundle
 /public/uploads
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem "bootsnap", require: false
 
 gem 'sorcery', "0.16.3"
 gem 'carrierwave', '~> 3.0'
+gem 'dotenv-rails'
+gem 'deepl-rb', require: 'deepl'
+gem 'httpclient'
 
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,11 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    deepl-rb (2.5.3)
+    dotenv (3.1.0)
+    dotenv-rails (3.1.0)
+      dotenv (= 3.1.0)
+      railties (>= 6.1)
     erubi (1.12.0)
     faker (3.2.3)
       i18n (>= 1.8.11, < 2)
@@ -109,6 +114,7 @@ GEM
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
+    httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -273,7 +279,10 @@ DEPENDENCIES
   carrierwave (~> 3.0)
   cssbundling-rails
   debug
+  deepl-rb
+  dotenv-rails
   faker
+  httpclient
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -1,4 +1,8 @@
 class DiariesController < ApplicationController
+  require 'httpclient'
+  require 'cgi' 
+  require 'deepl'
+
   def index
     @diaries = Diary.includes(:user)
   end
@@ -9,16 +13,30 @@ class DiariesController < ApplicationController
 
   def create
     @diary = current_user.diaries.build(diary_params)
-    if @diary.save
-      redirect_to diaries_path, success: "Today's Diary was created!"
-    else
-      flash.now[:danger] = "We can't create your diary. Could you try adain?"
-      render :new, status: :unprocessable_entity
-    end 
+    @translated_first_line = translate_to_english_back(@diary.first_line)
+    @translated_second_line = translate_to_english_back(@diary.second_line)
+    @translated_third_line = translate_to_english_back(@diary.third_line)
+
+    @diary.update(
+        translated_first_line: @translated_first_line,
+        translated_second_line: @translated_second_line,
+        translated_third_line: @translated_third_line,
+        translated: true
+      )
+      if @diary.save
+
+        redirect_to diary_path(@diary), success: "Today's Diary was created!"
+      else
+        flash.now[:danger] = "We can't create your diary. Could you try adain?"
+        render :new, status: :unprocessable_entity
+      end 
   end
 
   def show
     @diary = Diary.find(params[:id])
+    @translated_first_line = @diary.translated_first_line
+    @translated_second_line = @diary.translated_second_line
+    @translated_third_line = @diary.translated_third_line
     @comment = Comment.new
     @comments = @diary.comments.includes(:user).order(created_at: :desc)
   end
@@ -51,5 +69,41 @@ class DiariesController < ApplicationController
 
   def diary_params
     params.require(:diary).permit(:first_line, :second_line, :third_line, :diary_image, :diary_image_cache)
+  end
+
+  def translate_to_english_back(diary)
+    api_key = ENV['DEEPL_KEY']
+    uri = "https://api-free.deepl.com/v2/translate"
+    client = HTTPClient.new
+  
+    client.ssl_config.clear_cert_store
+    client.ssl_config.set_trust_ca("/etc/ssl/certs")
+    # ここでSSLなどの証明書情報を設定します。
+  
+    # 英語から日本語への翻訳
+    params_to_japanese = {
+      auth_key: api_key,
+      text: diary,
+      target_lang: "JA"
+    }
+  
+    response_to_japanese = client.get(uri, params_to_japanese)
+    parsed_response_to_japanese = JSON.parse(response_to_japanese.body)
+  
+    japanese_text = parsed_response_to_japanese["translations"][0]["text"]
+  
+    # 日本語から英語への翻訳
+    params_to_english = {
+      auth_key: api_key,
+      text: japanese_text,
+      target_lang: "EN"
+    }
+  
+    response_to_english = client.get(uri, params_to_english)
+    parsed_response_to_english = JSON.parse(response_to_english.body)
+  
+    english_text = parsed_response_to_english["translations"][0]["text"]
+
+    english_text
   end
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -13,7 +13,11 @@ class Diary < ApplicationRecord
   validates :third_line, presence: true, length: { maximum: 255 }
   validates :title, presence: true
 
-  private
+  def translated?
+    # translated フラグが true の場合に翻訳が完了していると判断します
+    return true
+  end
+
 
   def set_diary_title
     # 直近の日記のタイトルを取得

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container mb-5">
   <div class="row">
     <div class="col-lg-8 offset-lg-2">
       <h1>Diary</h1>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -26,11 +26,25 @@
               <% end %>
             </div>
           </div>
-          <p><%= simple_format(@diary.first_line) %></p>
-          <p><%= simple_format(@diary.second_line) %></p>
-          <p><%= simple_format(@diary.third_line) %></p>
+          <div class="container">
+            <div class="row">
+              <div class="col-md-6">
+                <strong>User's Lines</strong>
+                <p><%= simple_format(@diary.first_line) %></p>
+                <p><%= simple_format(@diary.second_line) %></p>
+                <p><%= simple_format(@diary.third_line) %></p>
+              </div>
+              <div class="col-md-6">
+                <strong>Modified Lines</strong>
+                <p><%= simple_format(@translated_first_line) %></p>
+                <p><%= simple_format(@translated_second_line) %></p>
+                <p><%= simple_format(@translated_third_line) %></p>
+              </div>
+            </div>
+          </div>
         </div>
       </article>
+      <%= link_to "Back to Index", diaries_path, class: "btn btn-primary" %>
     </div>
   </div>
   <!-- コメントフォーム -->

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer id='footer' class='footer-bottom fixed-bottom bg-info'>
+<footer id='footer' class='footer-bottom bg-info'>
   <div class='container'>
     <div class='row'>
       <div class='col-sm-6 col-12'>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
   resources :bookmarks, only: %i[create destroy]
   resource :profile, only: %i[show edit update]
 
-
   get 'login' => 'user_sessions#new', :as => :login
   post 'login' => "user_sessions#create"
   delete 'logout' => 'user_sessions#destroy', :as => :logout

--- a/db/migrate/20240301140900_add_translated_to_diaries.rb
+++ b/db/migrate/20240301140900_add_translated_to_diaries.rb
@@ -1,0 +1,8 @@
+class AddTranslatedToDiaries < ActiveRecord::Migration[7.0]
+  def change
+    add_column :diaries, :translated_first_line, :string
+    add_column :diaries, :translated_second_line, :string
+    add_column :diaries, :translated_third_line, :string
+    add_column :diaries, :translated, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_03_124318) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_01_140900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +43,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_03_124318) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "diary_image"
+    t.string "translated_first_line"
+    t.string "translated_second_line"
+    t.string "translated_third_line"
+    t.boolean "translated", default: false
     t.index ["user_id"], name: "index_diaries_on_user_id"
   end
 


### PR DESCRIPTION
### 概要
DeepLAPIの導入

### 内容

- [x] DeepL APIの導入
- [x] ユーザーが英文で書いたものを日本語に翻訳してそれを再度英文に翻訳するように設定
- [x] 新規作成と同時に翻訳した英文をDBに保存
- [x] showページで翻訳内容とユーザーが書いた文を表示

### 現在出ている不具合
- 新規作成をするとタイトルの数字がプラス２ずつ増えてしまう（Day２の次がDay４のように）  