### PR TITLE
背景画像の固定

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
         background-size: cover;
         position: relative;
         background-position: center;
+        background-attachment: fixed;
       }
       main {
         padding-bottom: 29px


### PR DESCRIPTION
背景画像がスクロールされると背景画像が何度も繰り返されてしまっていたため、background-attachment: fixed;を追加して固定。